### PR TITLE
Fix failing travis-ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
   include:
   - env: BUILD=cabal GHCVER=8.0.2 CABALVER=1.24
     compiler: ": #GHC 8.0.2"
-    addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
+    addons: {apt: {packages: [libasound2-dev,cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
 
 
 before_install:

--- a/mezzo.cabal
+++ b/mezzo.cabal
@@ -46,6 +46,7 @@ library
                      , Mezzo.Render
                      , Mezzo.Render.MIDI
                      , Mezzo.Render.Score
+                     , Mezzo.Render.Transform
 
   build-depends:       base >= 4.7 && < 5
                      , ghc-typelits-natnormalise


### PR DESCRIPTION
This fixes the failing travis-ci builds. I added libasound2-dev to the apt-get dependencies which is needed by PortMidi and added Mezzo.Render.Transform to the exposed-modules list. The latter might also fix the hackage upload.